### PR TITLE
Add buildactions support and more templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,39 +18,67 @@
     ],
     "activationEvents": [
         "onLanguage:csharp",
-        "onCommand:csharpextensions.createClass",
-        "onCommand:csharpextensions.createEnum",
-        "onCommand:csharpextensions.createInterface"
+        "onCommand:csharpextensions.changeBuildAction",
+        "onCommand:csharpextensions.createFolder",
+        "onCommand:csharpextensions.addFolder",
+        "onCommand:csharpextensions.createFile",
+        "onCommand:csharpextensions.addFiles",
+        "onCommand:csharpextensions.rename",
+        "onCommand:csharpextensions.remove"
     ],
     "main": "./out/src/extension",
     "contributes": {
         "commands": [
             {
-                "command": "csharpextensions.createClass",
-                "title": "New C# Class"
+                "command": "csharpextensions.createFolder",
+                "title": "Add new Folder to project"
             },
             {
-                "command": "csharpextensions.createInterface",
-                "title": "New C# Interface"
+                "command": "csharpextensions.createFile",
+                "title": "Add new File to project"
             },
             {
-                "command": "csharpextensions.createEnum",
-                "title": "New C# Enum"
+                "command": "csharpextensions.addFiles",
+                "title": "Add existing Files to project"
+            },
+            {
+                "command": "csharpextensions.rename",
+                "title": "Rename project item"
+            },
+            {
+                "command": "csharpextensions.remove",
+                "title": "Remove from project"
+            },
+            {
+                "command": "csharpextensions.changeBuildAction",
+                "title": "Change build action"
             }
         ],
         "menus": {
             "explorer/context": [
                 {
                     "group": "navigation@-1",
-                    "command": "csharpextensions.createClass"
+                    "command": "csharpextensions.createFile"
                 },
                 {
                     "group": "navigation@-1",
-                    "command": "csharpextensions.createInterface"
+                    "command": "csharpextensions.addFiles"
                 },
                 {
                     "group": "navigation@-1",
-                    "command": "csharpextensions.createEnum"
+                    "command": "csharpextensions.createFolder"
+                },
+                {
+                    "group": "navigation@-1",
+                    "command": "csharpextensions.rename"
+                },
+                {
+                    "group": "navigation@-1",
+                    "command": "csharpextensions.remove"
+                },
+                {
+                    "group": "navigation@-1",
+                    "command": "csharpextensions.changeBuildAction"
                 }
             ]
         },
@@ -91,6 +119,7 @@
     },
     "dependencies": {
         "find-up-glob": "^1.0.0",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.4.23",
+        "ncp": "^2.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -82,10 +82,10 @@
         "test": "mocha --require ts-node/register test/*.ts"
     },
     "devDependencies": {
-        "typescript": "^2.0.3",
+        "typescript": "^4.0.2",
         "vscode": "^1.0.0",
         "mocha": "^2.3.3",
-        "@types/node": "^6.0.40",
+        "@types/node": "^12.12.0",
         "@types/mocha": "^2.2.32",
         "ts-node": "^8.10.2"
     },

--- a/src/csprojWriter.ts
+++ b/src/csprojWriter.ts
@@ -1,0 +1,121 @@
+import * as path from 'path';
+import * as util from 'util';
+import { promises as fs } from 'fs';
+
+const findUpGlob = require('find-up-glob');
+const xml2js = require("xml2js");
+
+export enum BuildActions {
+    Folder = 'Folder',
+    Compile = 'Compile',
+    Content = 'Content',
+    EmbeddedResource = 'EmbeddedResource',
+    PRIResource = 'PRIResource',
+    Page = 'Page',
+    None = 'None',
+}
+
+export class CsProjWriter {
+    public async getProjFilePath(filePath: string): Promise<string | undefined> {
+        const
+            projItems: string[] = await findUpGlob('*.projitems', { cwd: path.dirname(filePath) }),
+            csProj: string[] = await findUpGlob('*.csproj', { cwd: path.dirname(filePath) });
+
+        if (projItems !== null && projItems.length >= 1) return projItems[0];
+        else if (csProj !== null && csProj.length >= 1) return csProj[0];
+
+        return undefined;
+    }
+
+    public async add(projPath: string, itemPath: string, itemType: BuildActions) {
+        var buildAction = await this.get(projPath, itemPath);
+        if (buildAction !== undefined) await this.remove(projPath, itemPath);
+
+        itemPath = itemPath.replace(path.dirname(projPath) + path.sep, path.extname(projPath) == '.projitems' ? "$(MSBuildThisFileDirectory)" : "");
+
+        const
+            xml = await fs.readFile(projPath, 'utf8'),
+            xmlParser = util.promisify(new xml2js.Parser().parseString),
+            xmlBuilder = new xml2js.Builder();
+
+        let parsedXml = await xmlParser(xml);
+        if (parsedXml === undefined || parsedXml.Project === undefined) return;
+
+        let obj = {
+            [itemType]: {
+                $: {
+                    'Include': itemPath
+                }
+            }
+        };
+
+        if (itemType === BuildActions.Compile && itemPath.endsWith('.xaml.cs')) {
+            console.log("TRUE")
+            var pagePath = itemPath.replace('.cs', '');
+            console.log(pagePath)
+            var pageBuildAction = await this.get(projPath, pagePath);
+            console.log(pageBuildAction)
+
+            if (pageBuildAction === BuildActions.Page) {
+                console.log(path.basename(pagePath))
+                Object(obj[itemType]).DependentUpon = path.basename(pagePath);
+            }
+        } else if (itemType === BuildActions.Page) {
+            Object(obj[itemType]).SubType = 'Designer';
+            Object(obj[itemType]).Generator = 'MSBuild:Compile';
+        }
+
+        var items: Array<Object> = parsedXml.Project.ItemGroup;
+        items.push(obj);
+
+        await fs.writeFile(projPath, xmlBuilder.buildObject(parsedXml));
+    }
+
+    public async get(projPath: string, itemPath: string) : Promise<BuildActions | undefined> {
+        itemPath = itemPath.replace(path.dirname(projPath) + path.sep, path.extname(projPath) == '.projitems' ? "$(MSBuildThisFileDirectory)" : "");
+
+        const
+            xml = await fs.readFile(projPath, 'utf8'),
+            xmlParser = util.promisify(new xml2js.Parser().parseString);
+
+        let parsedXml = await xmlParser(xml);
+        if (parsedXml === undefined || parsedXml.Project === undefined) return;
+        
+        var items: Array<Object> = parsedXml.Project.ItemGroup;
+
+        for (let item of items) {
+            var actions: Array<Object> = Object.keys(item).map(key => Object(item)[key])[0];
+            for (let action of actions) {
+                if (Object(action)["$"].Include === itemPath) return BuildActions[Object.getOwnPropertyNames(item)[0] as keyof typeof BuildActions];
+            }
+        }
+
+        return undefined;
+    }
+
+    public async remove(projPath: string, itemPath: string) {
+        itemPath = itemPath.replace(path.dirname(projPath) + path.sep, path.extname(projPath) == '.projitems' ? "$(MSBuildThisFileDirectory)" : "");
+
+        const
+            xml = await fs.readFile(projPath, 'utf8'),
+            xmlParser = util.promisify(new xml2js.Parser().parseString),
+            xmlBuilder = new xml2js.Builder();
+
+        let parsedXml = await xmlParser(xml);
+        if (parsedXml === undefined || parsedXml.Project === undefined) return;
+        
+        var items: Array<Object> = parsedXml.Project.ItemGroup;
+
+        for (let item of items) {
+            var actions: Array<Object> = Object.keys(item).map(key => Object(item)[key])[0];
+            for (let action of actions) {
+                if (Object(action)["$"].Include === itemPath) {
+                    actions.splice(actions.indexOf(action), 1);
+                    if (actions.length == 0) items.splice(items.indexOf(item), 1);
+                }
+            }
+        }
+
+        await fs.writeFile(projPath, xmlBuilder.buildObject(parsedXml));
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as fs from 'fs';
+import { promises as fs } from 'fs';
 import { CsProjWriter, BuildActions } from './csprojWriter';
 import CodeActionProvider from './codeActionProvider';
 import NamespaceDetector from './namespaceDetector';
@@ -11,9 +11,12 @@ export function activate(context: vscode.ExtensionContext) {
         scheme: 'file'
     };
 
-    context.subscriptions.push(vscode.commands.registerCommand('csharpextensions.createClass', createClass));
-    context.subscriptions.push(vscode.commands.registerCommand('csharpextensions.createInterface', createInterface));
-    context.subscriptions.push(vscode.commands.registerCommand('csharpextensions.createEnum', createEnum));
+    context.subscriptions.push(vscode.commands.registerCommand('csharpextensions.createFolder', createFolder));
+    context.subscriptions.push(vscode.commands.registerCommand('csharpextensions.createFile', createFile));
+    context.subscriptions.push(vscode.commands.registerCommand('csharpextensions.addFiles', addFiles));
+    context.subscriptions.push(vscode.commands.registerCommand('csharpextensions.remove', remove));
+    context.subscriptions.push(vscode.commands.registerCommand('csharpextensions.rename', rename));
+    context.subscriptions.push(vscode.commands.registerCommand('csharpextensions.changeBuildAction', change));
 
     const codeActionProvider = new CodeActionProvider();
 
@@ -22,60 +25,229 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(disposable);
 }
 
-function createClass(args: any) {
-    promptAndSave(args, 'class');
+async function createFolder(args: any) {
+    if (args == null) args = { _fsPath: vscode.workspace.rootPath };
+
+    let
+        incomingPath: string = args._fsPath || args.fsPath || args.path,
+        fileStat = await fs.lstat(incomingPath),
+        isDir = fileStat.isDirectory();
+
+    if (!isDir) incomingPath = path.dirname(incomingPath);
+
+    await promptAndAddAsync(incomingPath, 'folder');
 }
 
-function createInterface(args: any) {
-    promptAndSave(args, 'interface');
+async function createFile(args: any) {
+    if (args == null) args = { _fsPath: vscode.workspace.rootPath };
+
+    let
+        template = await vscode.window.showQuickPick([
+            { label: "Class", kind: "Class" },
+            { label: "Enum", kind: "Enum" },
+            { label: "Interface", kind: "Interface" },
+            { label: "Page", kind: "Page" },
+            { label: "UserControl", kind: "UserControl" },
+            { label: "Resource file (.resw)", kind: "Resource" }],
+            { ignoreFocusOut: true, placeHolder: 'Please select template' }),
+        incomingPath: string = args._fsPath || args.fsPath || args.path,
+        fileStat = await fs.lstat(incomingPath),
+        isDir = fileStat.isDirectory();
+
+    if (!isDir) incomingPath = path.dirname(incomingPath);
+    if (template === undefined) return;
+
+    await promptAndAddAsync(incomingPath, template.kind);
 }
 
-function createEnum(args: any) {
-    promptAndSave(args, 'enum');
-}
+async function addFiles(args: any) {
+    if (args == null) args = { _fsPath: vscode.workspace.rootPath };
 
-function promptAndSave(args: any, templatetype: string) {
-    if (args == null) {
-        args = { _fsPath: vscode.workspace.rootPath }
+    let
+        incomingPath: string = args._fsPath || args.fsPath || args.path,
+        fileStat = await fs.lstat(incomingPath),
+        isDir = fileStat.isDirectory();
+
+    if (!isDir) incomingPath = path.dirname(incomingPath);
+
+    let files = await vscode.window.showOpenDialog({ canSelectFiles: true, canSelectFolders: false, canSelectMany: true });
+    if (files === undefined) return;
+
+    let isPerFileAction = await yesNoPickAsync('Would you like to select the build action for each file individually?');
+    if (isPerFileAction === undefined) return;
+
+    var filePaths: string[] = [];
+    const ncp = require('ncp').ncp;
+    for (let fileUri of files) {
+        var sourcePath = fileUri.fsPath || fileUri.path;
+        var destinationPath = path.join(incomingPath, path.basename(sourcePath));
+
+        filePaths.push(destinationPath);
+
+        ncp.limit = 16;
+        ncp(sourcePath, destinationPath);
+
+        if (isPerFileAction) await selectBuildActionAndAdd([destinationPath]);
     }
-    let incomingpath: string = args._fsPath || args.fsPath || args.path;
 
-    vscode.window.showInputBox({ ignoreFocusOut: true, prompt: 'Please enter filename', value: 'new' + templatetype + '.cs' })
-        .then(async newfilename => {
-            if (typeof newfilename === 'undefined') return;
-
-            let newfilepath = incomingpath + path.sep + newfilename;
-
-            if (fs.existsSync(newfilepath)) {
-                vscode.window.showErrorMessage("File already exists");
-                return;
-            }
-
-            newfilepath = correctExtension(newfilepath);
-
-            const namespaceDetector = new NamespaceDetector(newfilepath);
-            const namespace = await namespaceDetector.getNamespace();
-            const typename = path.basename(newfilepath, '.cs');
-
-            openTemplateAndSaveNewFile(templatetype, namespace, typename, newfilepath);
-        }, errOnInput => {
-            console.error('Error on input', errOnInput);
-
-            vscode.window.showErrorMessage('Error on input. See extensions log for more info');
-        });
+    if (!isPerFileAction) await selectBuildActionAndAdd(filePaths);
 }
 
-function correctExtension(filename: string) {
-    if (path.extname(filename) !== '.cs') {
-        if (filename.endsWith('.')) filename = filename + 'cs';
-        else filename = filename + '.cs';
+async function remove(args: any) {
+    if (args == null) args = { _fsPath: vscode.workspace.rootPath };
+
+    let
+        incomingPath: string = args._fsPath || args.fsPath || args.path,
+        fileStat = await fs.lstat(incomingPath),
+        isDir = fileStat.isDirectory();
+
+    //TODO: Add support to delete multiple files --> https://github.com/microsoft/vscode/issues/3553 
+
+    let removeAction = await yesNoPickAsync("Are you sure you want to remove '" + path.basename(incomingPath) + "'?");
+    if (removeAction === undefined || !removeAction) return;
+
+    if (isDir) await removeFolderAsync(incomingPath);
+    else {
+        await fs.unlink(incomingPath);
+        await removeFromProjectAsync(incomingPath);
+    }
+}
+
+async function rename(args: any) {
+    if (args == null) args = { _fsPath: vscode.workspace.rootPath };
+
+    let incomingPath: string = args._fsPath || args.fsPath || args.path;
+    let fileExt = path.extname(incomingPath);
+
+    if (incomingPath.endsWith('.sln') ||
+        incomingPath.endsWith('.shproj') ||
+        incomingPath.endsWith('.projitems') ||
+        incomingPath.endsWith('.csproj') ||
+        incomingPath.endsWith('.user') ||
+        incomingPath.endsWith('project.json')) {
+        vscode.window.showErrorMessage("The name of this file cannot be changed");
+        return;
     }
 
-    return filename;
+    let newName = await vscode.window.showInputBox({ ignoreFocusOut: true, prompt: "Rename '" + path.basename(incomingPath) + "'", value: path.basename(incomingPath) });
+    if (newName === undefined) return;
+
+    let newFileExt = path.extname(newName);
+    let newPath = path.join(path.dirname(incomingPath), newName);
+
+    if (fileExt !== newFileExt) {
+        let removeAction = await yesNoPickAsync("Are you sure you want to change the extension Name from '" + fileExt + "' to '" + newFileExt + "'?");
+        if (removeAction === undefined || !removeAction) newFileExt = fileExt;
+    }
+
+    await fs.rename(incomingPath, newPath);
+
+    var buildAction = await getBuildActionAsync(incomingPath);
+    if (buildAction !== undefined) {
+        await removeFromProjectAsync(incomingPath);
+        await addToProjectAsync(newPath, buildAction);
+    }
 }
 
-function openTemplateAndSaveNewFile(type: string, namespace: string, filename: string, originalfilepath: string) {
-    const templatefileName = type + '.tmpl';
+async function change(args: any) {
+    if (args == null) args = { _fsPath: vscode.workspace.rootPath };
+
+    let
+        incomingPath: string = args._fsPath || args.fsPath || args.path,
+        fileStat = await fs.lstat(incomingPath),
+        isDir = fileStat.isDirectory();
+
+    //TODO: Add support to change multiple files --> https://github.com/microsoft/vscode/issues/3553 
+
+    if (isDir) {
+        vscode.window.showErrorMessage("The folder's build action cannot be changed");
+        return;
+    } else if (incomingPath.endsWith('.sln') ||
+        incomingPath.endsWith('.shproj') ||
+        incomingPath.endsWith('.projitems') ||
+        incomingPath.endsWith('.csproj') ||
+        incomingPath.endsWith('.user') ||
+        incomingPath === 'project.json') {
+        vscode.window.showErrorMessage("The build action of this file cannot be changed");
+        return;
+    }
+
+    await selectBuildActionAndAdd([incomingPath]);
+}
+
+async function selectBuildActionAndAdd(files: string[]) {
+    var items: Array<string> = [];
+
+    Object.keys(BuildActions).map(key => {
+        if (key === 'Folder' || key === 'PRIResource') return;
+        items.push(key);
+    });
+
+    let buildAction = await vscode.window.showQuickPick(items, { ignoreFocusOut: true, placeHolder: 'Please select build action for ' + (files.length > 1 ? 'files' : "'" + path.basename(files[0]) + "'") });
+    if (buildAction === undefined) return;
+
+    let buildType = BuildActions[buildAction as keyof typeof BuildActions];
+    for (let filePath of files) {
+        await addToProjectAsync(filePath, buildType);
+    }
+}
+
+async function promptAndAddAsync(incomingPath: string, templateType: string, fileName: string | undefined = undefined) {
+    if (templateType === 'folder') {
+        let folderName = await vscode.window.showInputBox({ ignoreFocusOut: true, prompt: 'Please enter foldername', value: 'new' + templateType });
+        if (folderName === undefined) return;
+
+        let folderPath = incomingPath + path.sep + folderName;
+
+        try {
+            await fs.access(folderPath);
+            vscode.window.showErrorMessage("Folder already exists");
+        } catch {
+            await fs.mkdir(folderPath);
+            await addToProjectAsync(folderPath, BuildActions.Folder);
+        }
+    } else {
+        let extName = "";
+        let buildAction = BuildActions.None;
+        let addCsFile = false;
+        let openBeside = false;
+
+        if (templateType === 'Resource') {
+            extName = '.resw';
+            buildAction = BuildActions.PRIResource;
+        } else if (templateType === 'Class' || templateType === 'Enum' || templateType === 'Interface' || templateType.endsWith('.cs')) {
+            extName = '.cs';
+            buildAction = BuildActions.Compile;
+        } else if (templateType === 'Page' || templateType === 'UserControl') {
+            extName = '.xaml';
+            buildAction = BuildActions.Page;
+            addCsFile = true;
+        }
+
+        if (fileName === undefined) fileName = await vscode.window.showInputBox({ ignoreFocusOut: true, prompt: 'Please enter filename', value: 'new' + templateType + extName });
+        else openBeside = true;
+        if (fileName === undefined) return;
+
+        let filePath = correctExtension(incomingPath + path.sep + fileName, extName);
+
+        try {
+            await fs.access(filePath);
+            vscode.window.showErrorMessage("File already exists");
+        } catch {
+            const
+                namespaceDetector = new NamespaceDetector(filePath),
+                namespace = await namespaceDetector.getNamespace(),
+                typename = path.basename(fileName, path.extname(fileName));
+
+            await writeFromTemplateAsync(templateType, namespace, typename, filePath, openBeside);
+            await addToProjectAsync(filePath, buildAction);
+
+            if (addCsFile) await promptAndAddAsync(incomingPath, templateType + '.cs', fileName);
+        }
+    }
+}
+
+async function writeFromTemplateAsync(type: string, namespace: string, filename: string, filePath: string, openBeside: boolean = false) {
     const extension = vscode.extensions.getExtension('kreativ-software.csharpextensions');
 
     if (!extension) {
@@ -83,37 +255,34 @@ function openTemplateAndSaveNewFile(type: string, namespace: string, filename: s
         return;
     }
 
-    const templateFilePath = path.join(extension.extensionPath, 'templates', templatefileName);
+    const templateFileName = type + '.tmpl';
+    const templateFilePath = path.join(extension.extensionPath, 'templates', templateFileName);
 
-    vscode.workspace.openTextDocument(templateFilePath)
-        .then(async doc => {
-            let text = doc.getText()
-                .replace('${namespace}', namespace)
-                .replace('${classname}', filename);
+    let template = await vscode.workspace.openTextDocument(templateFilePath);
+    let text = template.getText()
+        .split('${namespace}').join(namespace)
+        .split('${classname}').join(filename);
 
-            const cursorPosition = findCursorInTemplate(text);
+    const cursorPosition = findCursorInTemplate(text);
 
-            text = text.replace('${cursor}', '');
+    text = text.replace('${cursor}', '');
+    await fs.writeFile(filePath, text);
 
-            fs.writeFileSync(originalfilepath, text);
-            await addToProjectAsync(originalfilepath, BuildActions.Compile);
-            
-            vscode.workspace.openTextDocument(originalfilepath).then(doc => {
-                vscode.window.showTextDocument(doc).then(editor => {
-                    if (cursorPosition != null) {
-                        const newselection = new vscode.Selection(cursorPosition, cursorPosition);
+    const file = await vscode.workspace.openTextDocument(filePath);
+    const editor = await vscode.window.showTextDocument(file, openBeside ? {
+        viewColumn: vscode.ViewColumn.Beside
+    } : {});
 
-                        editor.selection = newselection;
-                    }
-                });
-            });
-        }, errTryingToCreate => {
-            const errorMessage = `Error trying to create file '${originalfilepath}' from template '${templatefileName}'`;
+    if (cursorPosition != null) editor.selection = new vscode.Selection(cursorPosition, cursorPosition);
+}
 
-            console.error(errorMessage, errTryingToCreate);
+async function getBuildActionAsync(path: string): Promise<BuildActions | undefined> {
+    const csproj = new CsProjWriter();
+    const proj = await csproj.getProjFilePath(path);
 
-            vscode.window.showErrorMessage(errorMessage);
-        });
+    if (proj !== undefined) return csproj.get(proj, path);
+
+    return undefined;
 }
 
 async function addToProjectAsync(path: string, type: BuildActions) {
@@ -121,6 +290,60 @@ async function addToProjectAsync(path: string, type: BuildActions) {
     const proj = await csproj.getProjFilePath(path);
 
     if (proj !== undefined) csproj.add(proj, path, type);
+}
+
+async function removeFromProjectAsync(path: string) {
+    const csproj = new CsProjWriter();
+    const proj = await csproj.getProjFilePath(path);
+
+    if (proj !== undefined) csproj.remove(proj, path);
+}
+
+async function removeFolderAsync(folderPath: string, removeContentOnly?: boolean) {
+    let files;
+
+    try {
+        files = await fs.readdir(folderPath);
+    } catch (error) {
+        throw new Error(error);
+    }
+
+    if (files.length) {
+        for (let fileName of files) {
+            let
+                filePath = path.join(folderPath, fileName),
+                fileStat = await fs.lstat(filePath),
+                isDir = fileStat.isDirectory();
+
+            if (isDir) await removeFolderAsync(filePath);
+            else {
+                await fs.unlink(filePath);
+                await removeFromProjectAsync(filePath);
+            }
+        }
+    }
+
+    if (!removeContentOnly) {
+        await fs.rmdir(folderPath);
+        await removeFromProjectAsync(folderPath);
+    }
+}
+
+async function yesNoPickAsync(message: string): Promise<boolean | undefined> {
+    var input = await vscode.window.showQuickPick(["No", "Yes"], { ignoreFocusOut: true, placeHolder: message });
+
+    if (input === undefined) return undefined;
+    else if (input === 'Yes') return true;
+    else return false;
+}
+
+function correctExtension(fileName: string, extName: string) {
+    if (path.extname(fileName) !== extName) {
+        if (fileName.endsWith('.')) fileName = fileName + extName.replace('.', '');
+        else fileName = fileName + extName;
+    }
+
+    return fileName;
 }
 
 function findCursorInTemplate(text: string): vscode.Position | null {


### PR DESCRIPTION
**Changes:**
- Use Promises with `async`/`await`
- Use vscode's `QuickPick api` to create a new file / selection template
- Some reformatting

**Added:**
- UWP Page template
- UWP UserControl template
- UWP Resource file (.resw) template
- Command to add existing files
- Command to create folder
- Command to rename files / folders
- Command to delete files / folders
- Command to change BuildAction entry for files in project
- Set BuildAction entry in project when creating new files, adding existing files, or creating folders
- Change BuildAction entry in project file when renaming files / folders
- Remove BuildAction entry from project file when deleting files / folders
- `csprojWriter.ts` file to get path of project file and `set`/`get`/`remove` BuildActions from project